### PR TITLE
Server+CI: Upgrade to Docker Compose V2

### DIFF
--- a/.github/workflows/server-cd.yml
+++ b/.github/workflows/server-cd.yml
@@ -92,5 +92,5 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: |
-            docker-compose pull
-            docker-compose up -d
+            docker compose pull
+            docker compose up -d

--- a/server/docker/dev/docker-compose.yml
+++ b/server/docker/dev/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: "baltic-stocks-dev"
 
 services:
   db:

--- a/server/docker/prod/docker-compose.yml
+++ b/server/docker/prod/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: "baltic-stocks-prod"
 
 services:
   db:


### PR DESCRIPTION
Compose v2 is GA! Relevant changes:
1. No more "version" field in docker-compose files -- Compose now
  follows the living Compose spec
2. The spec defines a "name" field to distinguish different compose
  projects. Utilize that for prod and dev docker-compose files
3. Compose must be called with "docker compose" instead of
  "docker-compose", switch to the new in server CI