### PR TITLE
Server: Add catch block to start-up data fetching

### DIFF
--- a/server/src/main/java/xyz/laane/server/service/importing/DataImportingJob.java
+++ b/server/src/main/java/xyz/laane/server/service/importing/DataImportingJob.java
@@ -76,7 +76,11 @@ public class DataImportingJob implements ApplicationListener<ApplicationReadyEve
         LocalDateTime lastFetch = batchRepository.findTopByOrderByTimestampDesc().getTimestamp();
         if (lastFetch.isBefore(LocalDateTime.now().minusDays(DataImportingJob.FETCH_FREQUENCY_DAYS))) {
             log.info("Current stock data is older than {} days. Fetching new data.", DataImportingJob.FETCH_FREQUENCY_DAYS);
-            updateAllStocks();
+            try {
+                updateAllStocks();
+            } catch (Exception e) {
+                log.error("Failed to update stocks: {}", e.getMessage(), e);
+            }
         } else {
             log.debug("Current stock data is fresh. Not fetching new data");
         }


### PR DESCRIPTION
This currently fails because the index site does not support IPv6. The server should tolerate this and continue execution instead of exiting.