### PR TITLE
Docs: Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat code with spotless
+845b702c938189a9bdc730bc933106c91f141305


### PR DESCRIPTION
No need to show formatting changes in git blame.